### PR TITLE
add a worker thread to periodically flush metrics

### DIFF
--- a/lib/prom_multi_proc/base.rb
+++ b/lib/prom_multi_proc/base.rb
@@ -5,7 +5,7 @@ module PromMultiProc
   class Base
     attr_reader :logger, :prefix, :writer
 
-    def initialize(socket:, metrics:, batch_size: 1, logger: nil, validate: false, prefix: "")
+    def initialize(socket:, metrics:, batch_size: 1, batch_timeout: 3, logger: nil, validate: false, prefix: "")
       @prefix = prefix
       @logger = logger || ::Logger.new(STDOUT)
 
@@ -14,7 +14,7 @@ module PromMultiProc
       end
 
       @metric_objects = Concurrent::Map.new
-      @writer = Writer.new(socket: socket, batch_size: batch_size, validate: validate)
+      @writer = Writer.new(socket: socket, batch_size: batch_size, batch_timeout: batch_timeout, validate: validate)
       @multi_lock = Mutex.new
 
       specs = get_specs(metrics)

--- a/lib/prom_multi_proc/rails.rb
+++ b/lib/prom_multi_proc/rails.rb
@@ -20,6 +20,12 @@ module PromMultiProc
         batch_size = 5
       end
 
+      if ENV.key?("PROM_MULTI_PROC_BATCH_TIMEOUT")
+        batch_timeout = ENV["PROM_MULTI_PROC_BATCH_TIMEOUT"].to_i
+      else
+        batch_timeout = 3
+      end
+
       if ::Rails.env.development? || ::Rails.env.test?
         validate = true
       else
@@ -32,13 +38,14 @@ module PromMultiProc
         logger = ::Logger.new(STDOUT)
       end
 
-      logger.error("Setting up prom_multi_proc for #{app_name}-#{program_name}, batch size: #{batch_size}, validate: #{validate}")
+      logger.error("Setting up prom_multi_proc for #{app_name}-#{program_name}, batch size: #{batch_size}, batch timeout: #{batch_timeout} validate: #{validate}")
 
       Base.new(
         prefix: prefix,
         socket: socket,
         metrics: metrics,
         batch_size: batch_size,
+        batch_timeout: batch_timeout,
         validate: validate,
         logger: logger
       )


### PR DESCRIPTION
Systems which produce a small number of metrics will have poor temporal precision on their metrics without this change, or in cases where the app is terminated, will fail to report metrics at all.

addresses https://github.com/DripEmail/drip/issues/11844